### PR TITLE
FFL-170 - Adjust the Dealer Name for Map Pin on Mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_*
 vendor/
+.vscode

--- a/core/view/frontend/web/css/source/_module.less
+++ b/core/view/frontend/web/css/source/_module.less
@@ -98,16 +98,17 @@ select.dealers-modal-button {
     vertical-align: middle;
     height: 40px;
 }
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 801px) {
     #ffl-input-search {
+        width: 95% !important;
         text-align: center !important;
-        font-size: 30px !important;
+        font-size: 20px !important;
         padding: 0 0 5px!important;
         font-weight: bold;
     }
     #ffl-input-search::placeholder {
         text-align: center !important;
-        font-size: 16px;
+        font-size: 12px;
         padding: 0 !important;
         font-weight: normal;
         max-height: 40px !important;
@@ -147,10 +148,35 @@ select.dealers-modal-button {
     }
     .ffl-map {
         flex: 0 1 100%;
+        .firstHeading {
+            font-size: 1.5rem;
+            margin-top: 0.5rem;
+            margin-bottom: 0.5rem;
+            font-weight: 500;
+        }
+        .popupContent {
+            width: 90%;
+            p {
+                margin-bottom: 0.5rem;
+                &:last-child {
+                    margin-top: 1rem;
+                    margin-bottom: 0;
+                }
+            }
+        }        
     }
     .flex-container-results {
         flex-direction: column-reverse !important;
         flex-wrap: nowrap !important;
+        .gm-style-iw  {
+            min-height: 180px;
+            min-width: 190px !important;
+        }
+        .gm-style-iw-d {
+            min-height: inherit;
+            min-width: inherit;
+
+        }
     }
     select.dealers-modal-button, .ffl-input-search {
         width: 95% !important;

--- a/core/view/frontend/web/js/cart/dealers-popup.js
+++ b/core/view/frontend/web/js/cart/dealers-popup.js
@@ -251,7 +251,7 @@ define([
         addPopupToMarker: function (marker, dealer) {
             var self = this;
             const contentString =
-                '<div style="display: none"><div id="popupcontent' + dealer.index + '">' +
+                '<div style="display: none"><div id="popupcontent' + dealer.index + '" class="popupContent">' +
                 '<div id="siteNotice' + dealer.index + '">' +
                 "</div>" +
                 '<h2 id="firstHeading" class="firstHeading">' + dealer.business_name_formatted + '</h2>' +


### PR DESCRIPTION
This PR includes:

- Font-weight style (mobile only) to distinguish the dealer’s name from the rest of the content on the pin
- Reduced the margin-top attribute so it would look better and aligned with the card styles.
- Adjusted the size of the input to align with the modal.
- Adjusted the font size of the placeholder for the input to be consistent.
- Set min-height and width for mobile devices so the pin popup won’t scroll. 