### PR TITLE
FRM-188 - Magento: Mixed Cart - Group FFLs and non-FFLs

### DIFF
--- a/checkout-multishipping/Block/Checkout/Addresses.php
+++ b/checkout-multishipping/Block/Checkout/Addresses.php
@@ -5,8 +5,49 @@
  */
 namespace RefactoredGroup\AutoFflCheckoutMultiShipping\Block\Checkout;
 
+use Magento\Customer\Model\Address\Config as AddressConfig;
+use RefactoredGroup\AutoFflCore\Helper\Data as Helper;
+
 class Addresses extends \Magento\Multishipping\Block\Checkout\Addresses
 {
+    /**
+     * @var Helper
+     */
+    private $helper;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Framework\Filter\DataObject\GridFactory $filterGridFactory
+     * @param \Magento\Multishipping\Model\Checkout\Type\Multishipping $multishipping
+     * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository
+     * @param AddressConfig $addressConfig
+     * @param \Magento\Customer\Model\Address\Mapper $addressMapper
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Framework\Filter\DataObject\GridFactory $filterGridFactory,
+        \Magento\Multishipping\Model\Checkout\Type\Multishipping $multishipping,
+        \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
+        AddressConfig $addressConfig,
+        \Magento\Customer\Model\Address\Mapper $addressMapper,
+        Helper $helper,
+        array $data = []
+    ) {
+        parent::__construct(
+            $context,
+            $filterGridFactory,
+            $multishipping,
+            $customerRepository,
+            $addressConfig,
+            $addressMapper,
+            $data
+        );
+        $this->helper = $helper;
+    }
+
     /**
      * Generate the address field name for the current cart item
      * @param $item
@@ -66,6 +107,14 @@ class Addresses extends \Magento\Multishipping\Block\Checkout\Addresses
             ->setExtraParams('data-mage-init=\'{ "RefactoredGroup_AutoFflCore/js/cart/handle-addresses-html-select": {} }\'');
 
         return $select->getHtml();
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasFflItem(): bool
+    {
+        return $this->helper->hasFflItem() ? true : false;
     }
 
     /**

--- a/checkout-multishipping/composer.json
+++ b/checkout-multishipping/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "refactored_group/autoffl-checkout-multishipping",
   "description": "AutomaticFFL Multi-Shipping Checkout extension",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "magento2-module",
   "license": "proprietary",
   "authors": [

--- a/checkout-multishipping/view/frontend/requirejs-config.js
+++ b/checkout-multishipping/view/frontend/requirejs-config.js
@@ -2,7 +2,8 @@ var config = {
     map: {
         '*': {
             handleCheckoutMultipleAddressButton: 'RefactoredGroup_AutoFflCheckoutMultiShipping/js/checkout/handle-checkout-multiple-address-button',
-            setupFflGrid: 'RefactoredGroup_AutoFflCheckoutMultiShipping/js/checkout/setup-ffl-grid'
+            setupFflGrid: 'RefactoredGroup_AutoFflCheckoutMultiShipping/js/checkout/setup-ffl-grid',
+            fflLoginRedirect: 'RefactoredGroup_AutoFflCheckoutMultiShipping/js/ffl-login-redirect',
         }
     },
     config: {

--- a/checkout-multishipping/view/frontend/templates/checkout/addresses.phtml
+++ b/checkout-multishipping/view/frontend/templates/checkout/addresses.phtml
@@ -13,6 +13,8 @@
 ?>
 <form id="checkout_multishipping_form"
       data-mage-init='{
+          "fflLoginRedirect":
+          {"hasFflItem": <?= (int)$block->hasFflItem() ?>},
           "multiShipping":
           {"itemsQty": <?= /* @noEscape */ (int)$block->getCheckout()->getQuote()->getItemsSummaryQty() ?>},
           "cartUpdate": {

--- a/checkout-multishipping/view/frontend/web/js/checkout/handle-checkout-multiple-address-button.js
+++ b/checkout-multishipping/view/frontend/web/js/checkout/handle-checkout-multiple-address-button.js
@@ -18,6 +18,7 @@ define([
          * dealer's address ID to false.
          */
         $(element).on('click', function (event) {
+            checkoutData.setFromCheckoutPage(true);
             checkoutData.setFflQuoteLineItemId(false);
             checkoutData.setFflProceedToCheckoutButtonPressed(false);
         });

--- a/checkout-multishipping/view/frontend/web/js/checkout/setup-ffl-grid.js
+++ b/checkout-multishipping/view/frontend/web/js/checkout/setup-ffl-grid.js
@@ -9,7 +9,9 @@ define([
     'use strict';
 
     return function (config, element) {
-        if (!checkoutData.isFflProceedToCheckoutButtonPressed()) return;
+        if (checkoutData.isFromCheckoutPage() &&
+            !checkoutData.isFflProceedToCheckoutButtonPressed()
+        ) return;
 
         /**
          * If the "Proceed To Checkout" button is clicked,

--- a/checkout-multishipping/view/frontend/web/js/ffl-login-redirect.js
+++ b/checkout-multishipping/view/frontend/web/js/ffl-login-redirect.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright © Refactored Group (https://www.refactored.group)
+ * @copyright Copyright © 2022. All rights reserved.
+ */
+
+define([
+    'Magento_Checkout/js/checkout-data'
+], function (checkoutData) {
+    'use strict';
+
+    /**
+     * The function checks if the customer comes from
+     * any page except the shopping cart page (e.g. from login page),
+     * it will check if the shopping cart contains FFL items.
+     * 
+     * If true, show only one shipping address option for
+     * both FFL and non-FFL items.
+     */
+    return function (config, element) {
+        if (!checkoutData.isFromCheckoutPage()) {
+            checkoutData.setFflProceedToCheckoutButtonPressed(
+                config.hasFflItem ? true : false
+            );
+        }
+    };
+});

--- a/checkout/composer.json
+++ b/checkout/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "refactored_group/autoffl-checkout",
   "description": "AutomaticFFL Checkout extension",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "magento2-module",
   "license": "proprietary",
   "authors": [

--- a/checkout/view/frontend/web/js/proceed-to-checkout-mixin.js
+++ b/checkout/view/frontend/web/js/proceed-to-checkout-mixin.js
@@ -20,6 +20,7 @@ define([
              * dealer's address ID to false.
              */
             $(element).on('click', function () {
+                checkoutData.setFromCheckoutPage(true);
                 checkoutData.setFflQuoteLineItemId(false);
                 checkoutData.setFflProceedToCheckoutButtonPressed(true);
             });

--- a/checkout/view/frontend/web/js/view/minicart-mixin.js
+++ b/checkout/view/frontend/web/js/view/minicart-mixin.js
@@ -25,6 +25,7 @@ define([
              */
             proceedToCheckoutListener: function () {
                 this.proceedToCheckoutButton.on('click', function () {
+                    checkoutData.setFromCheckoutPage(true);
                     checkoutData.setFflQuoteLineItemId(false);
                     checkoutData.setFflProceedToCheckoutButtonPressed(true);
                 });

--- a/core/composer.json
+++ b/core/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "refactored_group/autoffl-core",
   "description": "AutomaticFFL Core extension",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "type": "magento2-module",
   "license": "proprietary",
   "authors": [

--- a/core/view/frontend/web/js/cart/dealers-popup.js
+++ b/core/view/frontend/web/js/cart/dealers-popup.js
@@ -109,7 +109,9 @@ define([
                      * 
                      * First, it checks if the "Proceed to Checkout" button is clicked.
                      */
-                    if (checkoutData.isFflProceedToCheckoutButtonPressed()) {
+                    if (checkoutData.isFromCheckoutPage() &&
+                        checkoutData.isFflProceedToCheckoutButtonPressed()
+                    ) {
                         /**
                          * If true, fetch the row index of FFL items from localStorage.
                          * Then iterate through these items and assign the value of the ID

--- a/core/view/frontend/web/js/cart/handle-addresses-html-select.js
+++ b/core/view/frontend/web/js/cart/handle-addresses-html-select.js
@@ -14,7 +14,10 @@ define([
          * The value of all other select.ship_address elements will be based from this.
          */
         $(element).on('change', function (event) {
-            if (!checkoutData.isFflProceedToCheckoutButtonPressed()) return;
+            if (checkoutData.isFromCheckoutPage() &&
+                !checkoutData.isFflProceedToCheckoutButtonPressed()
+            ) return;
+
             const id = $(this).val();
             $('body').find('select.ship_address').val(id);
         });

--- a/core/view/frontend/web/js/cart/select-dealer-button.js
+++ b/core/view/frontend/web/js/cart/select-dealer-button.js
@@ -42,7 +42,9 @@ define([
              * If true, this will call the function to store the row index
              * of all FFL items to localStorage.
              */
-            if (checkoutData.isFflProceedToCheckoutButtonPressed()) {
+            if (checkoutData.isFromCheckoutPage() &&
+                checkoutData.isFflProceedToCheckoutButtonPressed()
+            ) {
                 self.addDealerIdToStorage(this.dealerButtonId);
             }
 

--- a/core/view/frontend/web/js/checkout-data-mixin.js
+++ b/core/view/frontend/web/js/checkout-data-mixin.js
@@ -72,6 +72,25 @@ define([
             return getData().fflQuoteLineItemId || false;
         };
 
+        /**
+         * Added this check to let Magento know that the button
+         * has been clicked from the main shopping cart page.
+         */
+        checkoutData.setFromCheckoutPage = function (data) {
+            var obj = getData();
+
+            obj.fromCheckoutPage = data;
+            saveData(obj);
+        };
+
+        /**
+         * 
+         * Getter function
+         */
+        checkoutData.isFromCheckoutPage = function () {
+            return getData().fromCheckoutPage || false;
+        };
+
         return checkoutData;
     };
 });


### PR DESCRIPTION
When session expires and the customer logs back in, fix the display of the address dropdown to show only one for FFL and non-FFL items.